### PR TITLE
adding logo link to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -137,6 +137,14 @@
         }
       ]
     },
+	{
+      "category": "logo",
+      "values": [
+        {
+          "value": "logo.png"
+        }
+      ]
+    },
     {
       "category": "contact",
       "values": [


### PR DESCRIPTION
This PR adds a logo link in the `extraProperties` section of the DATS.json file.